### PR TITLE
Adding Example #02A, adjusting requirements and cardinality

### DIFF
--- a/examples/core-example-01a.xml
+++ b/examples/core-example-01a.xml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <!--
     NAME          : Comic Book Schema (Core) - Example #01A
-    DESCRIPTION   : Basic XML description of Daredevil #67 using only required core elements.
-    SUMMARY       : The core schema only requires the usage of 7 elements to identify a work. These required elements include 
+    DESCRIPTION   : Basic XML record for Daredevil #67 using only required core elements.
+    SUMMARY       : The core schema only requires the usage of 6 elements to identify a work. These required elements include 
                     the publisher name, country, series title, series year, volume number, issue number, and language.
                     Note that no format, variance, condition, etc. has been specified. By adding additional properties to a
                     description we can begin to identify a specific example, or manifestation, of Daredevil #67, such as 
@@ -12,8 +12,7 @@
   <publisherName>Marvel Comics</publisherName>
   <country>US</country>
   <seriesTitle>Daredevil</seriesTitle>
-  <seriesYear>1963</seriesYear>
   <volumeNumber>1</volumeNumber>
-  <issueNumber>67</issueNumber>
+  <issueNumber>163</issueNumber>
   <language>en</language>
 </Comic>

--- a/examples/core-example-02a.xml
+++ b/examples/core-example-02a.xml
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    NAME          : Comic Book Schema (Core) - Example #02A
+    DESCRIPTION   : Detailed XML record for a specific manifestation of Daredevil #67
+    SUMMARY       : The creative work that represents Daredevil #67, i.e. the story, artwork, etc. can be embodied in multiple formats. It can be
+                    downloaded as a digital comic, reprinted in a collection of similar works, or reproduced long after the original publication date.
+                    In order to describe a specific manifestation, or example, of Daredevil #67 we need to add additional descriptive elements
+                    to our record. By further detailing which version of Daredevil #67 we are describing, we move closer to identifying
+                    a specific, tangible copy of Daredevil #67.
+                    
+                    Note in the example below we are using qualified XML elements, prefixed with "cbo", and we have repreated the
+                    <format> element in order specify that this record describes a color comic book. If we were to change this value
+                    to digital comic, we would be describing a different manifestation of Daredevil #67.
+  -->
+<cbo:Comic xmlns:cbo="http://comicmeta.org/cbo">
+  <cbo:publisherName>Marvel Comics</cbo:publisherName>
+  <cbo:country>US</cbo:country>
+  <cbo:seriesTitle>Daredevil</cbo:seriesTitle>
+  <cbo:seriesYear>1963</cbo:seriesYear>
+  <cbo:volumeNumber>1</cbo:volumeNumber>
+  <cbo:issueNumber>67</cbo:issueNumber>
+  <cbo:language>en</cbo:language>
+  <cbo:format>Color</cbo:format>
+  <cbo:format>ComicBook</cbo:format>
+  <cbo:edition>Newsstand</cbo:edition>
+  <cbo:printing>1</cbo:printing>
+</cbo:Comic>

--- a/src/cbo-core.xsd
+++ b/src/cbo-core.xsd
@@ -20,14 +20,14 @@
   <xs:element name="certNumber" type="xs:string"></xs:element>
   <xs:element name="country" type="xs:string"></xs:element>
   <xs:element name="imprintName" type="xs:string"></xs:element>
-  <xs:element name="issueNumber" type="xs:string"></xs:element>
+  <xs:element name="issueNumber" type="xs:string" default="1"></xs:element>
   <xs:element name="language" type="xs:string"></xs:element>
   <xs:element name="printing" type="xs:int"></xs:element>
   <xs:element name="publisherName" type="xs:string"></xs:element>
   <xs:element name="seriesTitle" type="xs:string"></xs:element>
   <xs:element name="seriesYear" type="xs:gYear"></xs:element>
   <xs:element name="variance" type="xs:string"></xs:element>
-  <xs:element name="volumeNumber" type="xs:string"></xs:element>
+  <xs:element name="volumeNumber" type="xs:string" default="1"></xs:element>
 
   <!-- // CLASSES //   -->
   <xs:complexType name="Collection">
@@ -47,14 +47,14 @@
       <xs:element ref="cbo:imprintName" minOccurs="0" maxOccurs="1"></xs:element>
       <xs:element ref="cbo:country" minOccurs="1" maxOccurs="1"></xs:element>
       <xs:element ref="cbo:seriesTitle" minOccurs="1" maxOccurs="1"></xs:element>
-      <xs:element ref="cbo:seriesYear" minOccurs="1" maxOccurs="1"></xs:element>
+      <xs:element ref="cbo:seriesYear" minOccurs="0" maxOccurs="1"></xs:element>
       <xs:element ref="cbo:volumeNumber" minOccurs="1" maxOccurs="1"></xs:element>
       <xs:element ref="cbo:issueNumber" minOccurs="1" maxOccurs="1"></xs:element>
       <xs:element ref="cbo:language" minOccurs="1" maxOccurs="1"></xs:element>
-      <xs:element name="format" type="cbo:Format" minOccurs="0" maxOccurs="1"></xs:element>
-      <xs:element name="edition" type="cbo:Edition" minOccurs="0" maxOccurs="1"></xs:element>
+      <xs:element name="format" type="cbo:Format" minOccurs="0" maxOccurs="unbounded"></xs:element>
+      <xs:element name="edition" type="cbo:Edition" minOccurs="0" maxOccurs="unbounded"></xs:element>
       <xs:element ref="cbo:printing" minOccurs="0" maxOccurs="1"></xs:element>
-      <xs:element ref="cbo:variance" minOccurs="0" maxOccurs="1"></xs:element>
+      <xs:element ref="cbo:variance" minOccurs="0" maxOccurs="unbounded"></xs:element>
       <xs:element name="condition" type="cbo:Condition" minOccurs="0" maxOccurs="1"></xs:element>
       <xs:element name="grade" type="cbo:Grade" minOccurs="0" maxOccurs="1"></xs:element>
       <xs:element ref="cbo:certNumber" minOccurs="0" maxOccurs="1"></xs:element>


### PR DESCRIPTION
Example #02A: Manifestation of Daredevil #67, and removal of seriesYear requirement. Adjusted cardinality of format, edition, and variance. Possible to combine these elements, i.e. a comic can be both a newsstand and limited edition.
